### PR TITLE
Expose common options as parameters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -4,4 +4,7 @@ parameters:
     =_metadata: {}
     namespace: openshift4-proxy
     trustedCA: null
+    httpProxy: null
+    httpsProxy: "${openshift4_proxy:httpProxy}"
+    noProxy: []
     spec: {}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -13,13 +13,16 @@ local ca_bundle = kube.ConfigMap(ca_bundle_name) {
   },
 };
 
-// see: https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html
-local proxy_config = kube._Object('config.openshift.io/v1', 'Proxy', 'cluster') {
-  spec+: params.spec {
-    [if has_ca_bundle then 'trustedCA']: {
-      name: ca_bundle_name,
-    },
+local spec = params.spec {
+  httpProxy: params.httpProxy,
+  httpsProxy: params.httpsProxy,
+  [if std.length(params.noProxy) > 0 then 'noProxy']: std.join(',', params.noProxy),
+  [if has_ca_bundle then 'trustedCA']: {
+    name: ca_bundle_name,
   },
+};
+local proxy_config = kube._Object('config.openshift.io/v1', 'Proxy', 'cluster') {
+  spec+: std.prune(spec),
 };
 
 // Define outputs below

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -2,17 +2,29 @@
 
 The parent key for all of the following parameters is `openshift4_proxy`.
 
-== `spec`
 
+== `httpProxy`
 [horizontal]
-type:: dict
-default:: `{}`
+type:: string
+default:: `null`
 
-OpenShift 4 Proxy configuration as documented in https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html["Configuring the cluster-wide proxy" in the official OpenShift docs].
+HTTP proxy to use.
 
-Also see: https://docs.openshift.com/container-platform/4.11/rest_api/config_apis/proxy-config-openshift-io-v1.html#spec[Proxy (config.openshift.io/v1) API documentation]
 
-Note that the `trustedCA` entry will be overwritten by the component. Put your certificates in `trustedCA` outside of `spec`
+== `httpsProxy`
+[horizontal]
+type:: string
+default:: _value of `httpProxy`_
+
+HTTPS proxy to use.
+
+
+== `noProxy`
+[horizontal]
+type:: array of strings
+default:: `[]`
+
+No-proxy list to use.
 
 
 == `trustedCA`
@@ -23,21 +35,35 @@ default:: `null`
 Additional CA certificates to be configured on the cluster. They will be stored in the `user-ca-bundle` ConfigMap in the `openshift-config` namespace.
 
 
+== `spec`
+
+[horizontal]
+type:: dict
+default:: `{}`
+
+Additional OpenShift 4 Proxy configuration as documented in https://docs.openshift.com/container-platform/latest/networking/enable-cluster-wide-proxy.html["Configuring the cluster-wide proxy" in the official OpenShift docs].
+
+Also see: https://docs.openshift.com/container-platform/4.11/rest_api/config_apis/proxy-config-openshift-io-v1.html#spec[Proxy (config.openshift.io/v1) API documentation]
+
+Note that the `httpProxy`, `httpsProxy`, `noProxy` and `trustedCA` entries will be overwritten by whatever was configured above.
+
+
 == Example
 
 
 [source,yaml]
 ----
-# Note that this entry is NOT under `spec`
+httpProxy: http://<username>:<pswd>@<ip>:<port>
+noProxy:
+  - example.com
+  - 10.20.30.0/24
+
 trustedCA: |
   -----BEGIN CERTIFICATE-----
   ...
   -----END CERTIFICATE-----
 
 spec:
-  httpProxy: http://<username>:<pswd>@<ip>:<port>
-  httpsProxy: http://<username>:<pswd>@<ip>:<port>
-  noProxy: example.com
   readinessEndpoints:
     - http://www.google.com
     - https://www.google.com

--- a/tests/golden/proxy/openshift4-proxy/openshift4-proxy/proxy_config.yaml
+++ b/tests/golden/proxy/openshift4-proxy/openshift4-proxy/proxy_config.yaml
@@ -6,8 +6,8 @@ metadata:
     name: cluster
   name: cluster
 spec:
-  httpProxy: http://example.com:1234/
-  httpsProxy: http://example.com:1234/
+  httpProxy: http://example.com:1234
+  httpsProxy: http://example.com:1234
   noProxy: example.com,foo.com
   readinessEndpoints:
     - http://www.google.com

--- a/tests/proxy.yml
+++ b/tests/proxy.yml
@@ -1,14 +1,16 @@
 ---
 parameters:
   openshift4_proxy:
+    httpProxy: http://example.com:1234
+    noProxy:
+      - example.com
+      - foo.com
+    readinessEndpoints:
     trustedCA: |
       -----BEGIN CERTIFICATE-----
       ...
       -----END CERTIFICATE-----
     spec:
-      httpProxy: http://example.com:1234/
-      httpsProxy: http://example.com:1234/
-      noProxy: example.com,foo.com
       readinessEndpoints:
         - http://www.google.com
         - https://www.google.com


### PR DESCRIPTION
This allows for more ergonomic configuration.

- default `httpsProxy` to the value of `httpProxy`
- expose `noProxy` as a list


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

