### PR TITLE
Don't prune generated CA bundles

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -8,6 +8,13 @@ local params = inv.parameters.openshift4_proxy;
 local has_ca_bundle = params.trustedCA != null;
 local ca_bundle_name = 'user-ca-bundle';
 local ca_bundle = kube.ConfigMap(ca_bundle_name) {
+  metadata+: {
+    annotations+: {
+      // configure ArgoCD to ignore the copy of this configmap which is created by OpenShift
+      'argocd.argoproj.io/sync-options': 'Prune=false',
+      'argocd.argoproj.io/compare-options': 'IgnoreExtraneous',
+    },
+  },
   data: {
     'ca-bundle.crt': params.trustedCA,
   },

--- a/tests/golden/proxy/openshift4-proxy/openshift4-proxy/user-ca-bundle.yaml
+++ b/tests/golden/proxy/openshift4-proxy/openshift4-proxy/user-ca-bundle.yaml
@@ -9,7 +9,9 @@ data:
     '
 kind: ConfigMap
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/compare-options: IgnoreExtraneous
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     name: user-ca-bundle
   name: user-ca-bundle


### PR DESCRIPTION
OpenShift will copy the user-ca ConfigMap to other places. This commit adds an annotation that tells ArgoCD to not prune those copies.


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
